### PR TITLE
makefile: don't link lpng12 by default

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -18,9 +18,9 @@ ASMFLAGS =
 #endif
 
 ifdef STATICDIR
-	LIBS =  $(STATICLIBS) -lz -lm -ldl -lfreetype -lpng12 -ljpeg 
+	LIBS =  $(STATICLIBS) -lz -lm -ldl -lfreetype -lpng -ljpeg 
 else
-	LIBS =  -lSDL -lSDL_ttf -lSDL_image -lz -lm -ldl -lfreetype -lpng12 -ljpeg 
+	LIBS =  -lSDL -lSDL_ttf -lSDL_image -lz -lm -ldl -lfreetype -lpng -ljpeg 
 endif
 
 capriceRPI: cap32.cpp menu.o autotype.o crtc.o fdc.o psg.o tape.o z80.o cap32.h z80.h autoboot.c vjoystick.c

--- a/src/makefile.dynamic
+++ b/src/makefile.dynamic
@@ -18,9 +18,9 @@ ASMFLAGS =
 #endif
 
 ifdef STATICDIR
-	LIBS =  $(STATICLIBS) -lz -lm -ldl -lfreetype -lpng12 -ljpeg 
+	LIBS =  $(STATICLIBS) -lz -lm -ldl -lfreetype -lpng -ljpeg 
 else
-	LIBS =  -lSDL -lSDL_ttf -lSDL_image -lz -lm -ldl -lfreetype -lpng12 -ljpeg 
+	LIBS =  -lSDL -lSDL_ttf -lSDL_image -lz -lm -ldl -lfreetype -lpng -ljpeg 
 endif
 
 capriceRPI: cap32.cpp menu.o autotype.o crtc.o fdc.o psg.o tape.o z80.o cap32.h z80.h autoboot.c vjoystick.c

--- a/src/makefile.notpi
+++ b/src/makefile.notpi
@@ -18,9 +18,9 @@ ASMFLAGS =
 #endif
 
 ifdef STATICDIR
-	LIBS =  $(STATICLIBS) -lz -lm -ldl -lfreetype -lpng12 -ljpeg 
+	LIBS =  $(STATICLIBS) -lz -lm -ldl -lfreetype -lpng -ljpeg 
 else
-	LIBS =  -lSDL -lSDL_ttf -lSDL_image -lz -lm -ldl -lfreetype -lpng12 -ljpeg 
+	LIBS =  -lSDL -lSDL_ttf -lSDL_image -lz -lm -ldl -lfreetype -lpng -ljpeg 
 endif
 
 capriceRPI-notpi: cap32.cpp menu.o autotype.o crtc.o fdc.o psg.o tape.o z80.o cap32.h z80.h autoboot.c vjoystick.c

--- a/src/makefile.old
+++ b/src/makefile.old
@@ -15,7 +15,7 @@ CFLAGS  = $(GFLAGS) -O2 -funroll-loops -ffast-math -fomit-frame-pointer -fno-str
 #CFLAGS  = $(GFLAGS) -gstabs+ -static
 #endif
 
-LIBS =  $(STATICLIBS) -lz  -lm -lfreetype -lpng12 -ljpeg 
+LIBS =  $(STATICLIBS) -lz  -lm -lfreetype -lpng -ljpeg 
 
 
 capriceRPI2: cap32.cpp menu.o autotype.o crtc.o fdc.o psg.o tape.o z80.o cap32.h z80.h

--- a/src/makefile.static
+++ b/src/makefile.static
@@ -18,9 +18,9 @@ ASMFLAGS =
 #endif
 
 ifdef STATICDIR
-	LIBS =  $(STATICLIBS) -lz -lm -ldl -lfreetype -lpng12 -ljpeg 
+	LIBS =  $(STATICLIBS) -lz -lm -ldl -lfreetype -lpng -ljpeg 
 else
-	LIBS =  -lSDL -lSDL_ttf -lSDL_image -lz -lm -ldl -lfreetype -lpng12 -ljpeg 
+	LIBS =  -lSDL -lSDL_ttf -lSDL_image -lz -lm -ldl -lfreetype -lpng -ljpeg 
 endif
 
 capriceRPI-static: cap32.cpp menu.o autotype.o crtc.o fdc.o psg.o tape.o z80.o cap32.h z80.h autoboot.c vjoystick.c


### PR DESCRIPTION
On Raspbian stretch, libpng12-dev conflicts with libpng-dev, which
is a dependency to libsdl1.2-dev through libcaca-dev, thus preventing
successful building.